### PR TITLE
fix hostname to match docs

### DIFF
--- a/tracker-app-config.yaml
+++ b/tracker-app-config.yaml
@@ -71,7 +71,7 @@ spec:
       - name: ingress
         parameterValues:
           - name: hostname
-            value: oam.servicetracker.io
+            value: servicetracker.oam.io
           - name: path
             value: / 
           - name: service_port


### PR DESCRIPTION
The hostname in the app config was oam.servicetracker.io whereas the docs mentioned servicetracker.oam.io so I just changed the hostname in the app config to match docs. 