### PR TITLE
Migrating Tracker App to oam spec v1alpha2.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,9 @@ TestResult.xml
 [Rr]eleasePS/
 dlldata.c
 
+# MacOS
+.DS_Store
+
 # Benchmark Results
 BenchmarkDotNet.Artifacts/
 

--- a/2.ServiceTracker_App/ApplicationConfiguration/tracker-app-config.yaml
+++ b/2.ServiceTracker_App/ApplicationConfiguration/tracker-app-config.yaml
@@ -1,11 +1,10 @@
-apiVersion: core.oam.dev/v1alpha1
+apiVersion: core.oam.dev/v1alpha2
 kind: ApplicationConfiguration
 metadata:
   name: service-tracker
 spec:
   components:
     - componentName: tracker-postgres-db
-      instanceName: postgres
       parameterValues:
         - name: dbuser
           value: dbuser
@@ -14,7 +13,6 @@ spec:
         - name: database
           value: hackfest  
     - componentName: data-api
-      instanceName: data-api
       parameterValues:
         - name: dbuser
           value: "dbuser"
@@ -31,7 +29,6 @@ spec:
         - name: dboptions
           value: ""
     - componentName: flights-api
-      instanceName: flights-api
       parameterValues:
         - name: dataUri
           value: "http://data-api.default.svc.cluster.local:3009/"
@@ -41,7 +38,6 @@ spec:
             - name: replicaCount
               value: 2
     - componentName: quakes-api
-      instanceName: quakes-api
       parameterValues:
         - name: dataUri
           value: "http://data-api.default.svc.cluster.local:3009/"  
@@ -51,7 +47,6 @@ spec:
             - name: replicaCount
               value: 2       
     - componentName: weather-api
-      instanceName: weather-api
       parameterValues:
         - name: dataUri
           value: "http://data-api.default.svc.cluster.local:3009/"
@@ -61,7 +56,6 @@ spec:
             - name: replicaCount
               value: 2        
     - componentName: service-tracker-ui
-      instanceName: service-tracker-ui
       parameterValues:
         - name: flightsUri
           value: "http://flights-api.default.svc.cluster.local:3003/"

--- a/2.ServiceTracker_App/ComponentSchematic/tracker-data-component.yaml
+++ b/2.ServiceTracker_App/ComponentSchematic/tracker-data-component.yaml
@@ -1,11 +1,73 @@
-apiVersion: core.oam.dev/v1alpha1
-kind: ComponentSchematic
+apiVersion: core.oam.dev/v1alpha2
+kind: Component
 metadata:
   name: data-api
 spec:
-  workloadType: core.oam.dev/v1alpha1.Server
-  osType: linux
-  arch: amd64
+  workload:
+    apiVersion: core.oam.dev/v1alpha2
+    kind: ContainerizedWorkload
+    metadata:
+      name: service-workload
+    spec:
+      osType: linux
+      arch: amd64
+      containers:
+        - name: data-api
+          image: artursouza/rudr-data-api:0.50
+          env:
+            - name: DATABASE_USER
+              value: "dbuser"
+              fromParam: "dbuser"
+            - name: DATABASE_PASSWORD
+              value: "dbpassword"
+              fromParam: "dbpassword"
+            - name: DATABASE_NAME
+              value: "mydatabase"      
+              fromParam: dbname
+            - name: DATABASE_HOSTNAME
+              value: "localhost"      
+              fromParam: dbhostname
+            - name: DATABASE_PORT
+              value: "5432"        
+              fromParam: dbport  
+            - name: DATABASE_DRIVER
+              value: "postgres"    
+              fromParam: dbdriver
+            - name: DATABASE_OPTIONS
+              value:
+              fromParam: dboptions
+          ports:
+            - name: http
+              containerPort: 3009
+              protocol: TCP
+          readinessProbe:
+            exec:
+              command:
+                - wget
+                - -q
+                - 'http://127.0.0.1:3009/status'
+                - -O
+                - /dev/null
+                - -S
+            failureThreshold: 6
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 5
+          livenessProbe:
+            exec:
+              command:
+                - wget
+                - -q
+                - 'http://127.0.0.1:3009/status'
+                - -O
+                - /dev/null
+                - -S
+            failureThreshold: 6
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 5 
   parameters:
     - name: dbuser
       description: database username
@@ -35,60 +97,3 @@ spec:
       description: config as JSON
       type: string
       required: false
-  containers:
-    - name: data-api
-      image: artursouza/rudr-data-api:0.50
-      env:
-        - name: DATABASE_USER
-          value: "dbuser"
-          fromParam: "dbuser"
-        - name: DATABASE_PASSWORD
-          value: "dbpassword"
-          fromParam: "dbpassword"
-        - name: DATABASE_NAME
-          value: "mydatabase"      
-          fromParam: dbname
-        - name: DATABASE_HOSTNAME
-          value: "localhost"      
-          fromParam: dbhostname
-        - name: DATABASE_PORT
-          value: "5432"        
-          fromParam: dbport  
-        - name: DATABASE_DRIVER
-          value: "postgres"    
-          fromParam: dbdriver
-        - name: DATABASE_OPTIONS
-          value:
-          fromParam: dboptions
-      ports:
-        - name: http
-          containerPort: 3009
-          protocol: TCP
-      readinessProbe:
-        exec:
-          command:
-            - wget
-            - -q
-            - 'http://127.0.0.1:3009/status'
-            - -O
-            - /dev/null
-            - -S
-        failureThreshold: 6
-        initialDelaySeconds: 5
-        periodSeconds: 10
-        successThreshold: 1
-        timeoutSeconds: 5
-      livenessProbe:
-        exec:
-          command:
-            - wget
-            - -q
-            - 'http://127.0.0.1:3009/status'
-            - -O
-            - /dev/null
-            - -S
-        failureThreshold: 6
-        initialDelaySeconds: 30
-        periodSeconds: 10
-        successThreshold: 1
-        timeoutSeconds: 5 

--- a/2.ServiceTracker_App/ComponentSchematic/tracker-db-component.yaml
+++ b/2.ServiceTracker_App/ComponentSchematic/tracker-db-component.yaml
@@ -1,11 +1,51 @@
-apiVersion: core.oam.dev/v1alpha1
-kind: ComponentSchematic
+apiVersion: core.oam.dev/v1alpha2
+kind: Component
 metadata:
   name: tracker-postgres-db
 spec:
-  workloadType: core.oam.dev/v1alpha1.Server
-  osType: linux
-  arch: amd64
+  workload:
+    apiVersion: core.oam.dev/v1alpha2
+    kind: ContainerizedWorkload
+    metadata:
+      name: db-workload
+    spec:
+      osType: linux
+      arch: amd64
+      containers:
+        - name: postgres
+          image: docker.io/postgres:9.6.17-alpine
+          env:
+            - name: POSTGRES_USER
+              value: "postgres"
+              fromParam: "dbuser"
+            - name: POSTGRES_PASSWORD
+              value: "dbpassword"
+              fromParam: "dbpassword"
+            - name: POSTGRES_DB
+              value: "hackfest"  
+              fromParam: "database"
+          ports:
+            - name: postgres
+              containerPort: 5432
+              protocol: TCP
+          readinessProbe:
+            exec:
+              command:
+                - echo
+            failureThreshold: 6
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 5
+          livenessProbe:
+            exec:
+              command:
+                - echo
+            failureThreshold: 6
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 5   
   parameters:
     - name: dbuser
       description: database username
@@ -18,39 +58,4 @@ spec:
     - name: database
       description: new database
       type: string
-      required: false                 
-  containers:
-    - name: postgres
-      image: docker.io/postgres:9.6.17-alpine   
-      env:
-        - name: POSTGRES_USER
-          value: "postgres"
-          fromParam: "dbuser"
-        - name: POSTGRES_PASSWORD
-          value: "dbpassword"
-          fromParam: "dbpassword"
-        - name: POSTGRES_DB
-          value: "hackfest"  
-          fromParam: "database"
-      ports:
-        - name: postgres
-          containerPort: 5432
-          protocol: TCP
-      readinessProbe:
-        exec:
-          command:
-            - echo
-        failureThreshold: 6
-        initialDelaySeconds: 5
-        periodSeconds: 10
-        successThreshold: 1
-        timeoutSeconds: 5
-      livenessProbe:
-        exec:
-          command:
-            - echo
-        failureThreshold: 6
-        initialDelaySeconds: 30
-        periodSeconds: 10
-        successThreshold: 1
-        timeoutSeconds: 5        
+      required: false     

--- a/2.ServiceTracker_App/ComponentSchematic/tracker-flights-component.yaml
+++ b/2.ServiceTracker_App/ComponentSchematic/tracker-flights-component.yaml
@@ -1,24 +1,29 @@
-apiVersion: core.oam.dev/v1alpha1
-kind: ComponentSchematic
+apiVersion: core.oam.dev/v1alpha2
+kind: Component
 metadata:
   name: flights-api
 spec:
-  workloadType: core.oam.dev/v1alpha1.Server
-  osType: linux
-  arch: amd64
+  workload:
+    apiVersion: core.oam.dev/v1alpha2
+    kind: ContainerizedWorkload
+    metadata:
+      name: service-workload
+    spec:
+      osType: linux
+      arch: amd64
+      containers:
+        - name: flights-api
+          image: sonofjorel/rudr-flights-api:0.49  
+          env:
+            - name: DATA_SERVICE_URI
+              value: "foo"
+              fromParam: "dataUri"  
+          ports:
+            - name: http
+              containerPort: 3003
+              protocol: TCP
   parameters:
     - name: dataUri
       description: uri for data-api pod
       type: string
-      required: true           
-  containers:
-    - name: flights-api
-      image: sonofjorel/rudr-flights-api:0.49   
-      env:
-        - name: DATA_SERVICE_URI
-          value: "foo"
-          fromParam: "dataUri"  
-      ports:
-        - name: http
-          containerPort: 3003
-          protocol: TCP
+      required: true

--- a/2.ServiceTracker_App/ComponentSchematic/tracker-quakes-component.yaml
+++ b/2.ServiceTracker_App/ComponentSchematic/tracker-quakes-component.yaml
@@ -1,24 +1,30 @@
-apiVersion: core.oam.dev/v1alpha1
-kind: ComponentSchematic
+apiVersion: core.oam.dev/v1alpha2
+kind: Component
 metadata:
   name: quakes-api
 spec:
-  workloadType: core.oam.dev/v1alpha1.Server
-  osType: linux
-  arch: amd64
+  workload:
+    apiVersion: core.oam.dev/v1alpha2
+    kind: ContainerizedWorkload
+    metadata:
+      name: service-workload
+    spec:
+      osType: linux
+      arch: amd64
+      containers:
+        - name: quakes-api
+        image: sonofjorel/rudr-quakes-api:0.49   
+        env:
+          - name: DATA_SERVICE_URI
+            value: "foo"
+            fromParam: "dataUri"  
+        ports:
+          - name: http
+            containerPort: 3012
+            protocol: TCP
   parameters:
     - name: dataUri
       description: uri for data-api pod
       type: string
-      required: true           
-  containers:
-    - name: quakes-api
-      image: sonofjorel/rudr-quakes-api:0.49   
-      env:
-        - name: DATA_SERVICE_URI
-          value: "foo"
-          fromParam: "dataUri"  
-      ports:
-        - name: http
-          containerPort: 3012
-          protocol: TCP
+      required: true
+

--- a/2.ServiceTracker_App/ComponentSchematic/tracker-ui-component.yaml
+++ b/2.ServiceTracker_App/ComponentSchematic/tracker-ui-component.yaml
@@ -1,11 +1,33 @@
-apiVersion: core.oam.dev/v1alpha1
-kind: ComponentSchematic
+apiVersion: core.oam.dev/v1alpha2
+kind: Component
 metadata:
   name: service-tracker-ui
 spec:
-  workloadType: core.oam.dev/v1alpha1.Server
-  osType: linux
-  arch: amd64
+  workload:
+    apiVersion: core.oam.dev/v1alpha2
+    kind: ContainerizedWorkload
+    metadata:
+      name: webui-workload
+    spec:
+      osType: linux
+      arch: amd64
+      containers:
+        - name: service-tracker-ui
+          image: sonofjorel/rudr-web-ui:0.49   
+          env:
+            - name: FLIGHT_API_ROOT
+              value: "foo"
+              fromParam: "flightsUri"
+            - name: WEATHER_API_ROOT
+              value: "foo"
+              fromParam: "weatherUri"
+            - name: QUAKES_API_ROOT
+              value: "foo"
+              fromParam: "quakesUri"                    
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
   parameters:
     - name: flightsUri
       description: uri for flights-api pod
@@ -18,21 +40,5 @@ spec:
     - name: quakesUri
       description: uri for quakes-api pod
       type: string
-      required: true            
-  containers:
-    - name: service-tracker-ui
-      image: sonofjorel/rudr-web-ui:0.49   
-      env:
-        - name: FLIGHT_API_ROOT
-          value: "foo"
-          fromParam: "flightsUri"
-        - name: WEATHER_API_ROOT
-          value: "foo"
-          fromParam: "weatherUri"
-        - name: QUAKES_API_ROOT
-          value: "foo"
-          fromParam: "quakesUri"                    
-      ports:
-        - name: http
-          containerPort: 8080
-          protocol: TCP
+      required: true
+        

--- a/2.ServiceTracker_App/ComponentSchematic/tracker-weather-component.yaml
+++ b/2.ServiceTracker_App/ComponentSchematic/tracker-weather-component.yaml
@@ -1,24 +1,29 @@
-apiVersion: core.oam.dev/v1alpha1
-kind: ComponentSchematic
+apiVersion: core.oam.dev/v1alpha2
+kind: Component
 metadata:
   name: weather-api
 spec:
-  workloadType: core.oam.dev/v1alpha1.Server
-  osType: linux
-  arch: amd64
+  workload:
+    apiVersion: core.oam.dev/v1alpha2
+    kind: ContainerizedWorkload
+    metadata:
+      name: service-workload
+    spec:
+      osType: linux
+      arch: amd64
+      containers:
+        - name: weather-api
+        image: sonofjorel/rudr-weather-api:0.49    
+        env:
+          - name: DATA_SERVICE_URI
+            value: "foo"
+            fromParam: "dataUri"  
+        ports:
+          - name: http
+            containerPort: 3015
+            protocol: TCP
   parameters:
     - name: dataUri
       description: uri for data-api pod
       type: string
-      required: true           
-  containers:
-    - name: weather-api
-      image: sonofjorel/rudr-weather-api:0.49    
-      env:
-        - name: DATA_SERVICE_URI
-          value: "foo"
-          fromParam: "dataUri"  
-      ports:
-        - name: http
-          containerPort: 3015
-          protocol: TCP
+      required: true


### PR DESCRIPTION
Migrating Tracker App to oam spec v1alpha2.

To consume params, I've used the same way as v1alpha1. I do believe that is a better way than the fieldPath introduced in v1alpha2 - maybe we can support both and simply keep the v1alpha1 way. I am creating an issue in the specs repo for this discussion.